### PR TITLE
Cleanup

### DIFF
--- a/live/development/stack_vars.hcl
+++ b/live/development/stack_vars.hcl
@@ -1,6 +1,0 @@
-locals {
-  environment = "development"
-  location    = "us"
-  region      = "us-central1"
-  project_id  = get_env("TG_DEVELOPMENT_GCP_PROJECT")
-}

--- a/live/development/terragrunt.stack.hcl
+++ b/live/development/terragrunt.stack.hcl
@@ -1,6 +1,8 @@
 locals {
-  stack_vars = read_terragrunt_config("stack_vars.hcl")
-  location   = local.stack_vars.locals.location
+  environment = "development"
+  location    = "us"
+  region      = "us-central1"
+  project_id  = get_env("TG_DEVELOPMENT_GCP_PROJECT")
 }
 
 stack "common" {

--- a/live/development/terragrunt.stack.hcl
+++ b/live/development/terragrunt.stack.hcl
@@ -9,8 +9,5 @@ stack "common" {
   source = "${get_repo_root()}/stacks/common"
   path   = "common"
 
-  values = {
-    environment = local.environment
-    location    = local.location
-  }
+  values = local
 }

--- a/live/production-eu/stack_vars.hcl
+++ b/live/production-eu/stack_vars.hcl
@@ -1,6 +1,0 @@
-locals {
-  environment = "production-eu"
-  location    = "europe"
-  region      = "europe-west3"
-  project_id  = get_env("TG_PRODUCTION_EU_GCP_PROJECT")
-}

--- a/live/production-eu/terragrunt.stack.hcl
+++ b/live/production-eu/terragrunt.stack.hcl
@@ -1,7 +1,8 @@
 locals {
-  stack_vars  = read_terragrunt_config("stack_vars.hcl")
-  environment = local.stack_vars.locals.environment
-  location    = local.stack_vars.locals.location
+  environment = "production-eu"
+  location    = "europe"
+  region      = "europe-west3"
+  project_id  = get_env("TG_PRODUCTION_EU_GCP_PROJECT")
 }
 
 stack "common" {

--- a/live/production/stack_vars.hcl
+++ b/live/production/stack_vars.hcl
@@ -1,6 +1,0 @@
-locals {
-  environment = "production"
-  location    = "us"
-  region      = "us-central1"
-  project_id  = get_env("TG_PRODUCTION_GCP_PROJECT")
-}

--- a/live/production/terragrunt.stack.hcl
+++ b/live/production/terragrunt.stack.hcl
@@ -1,6 +1,8 @@
 locals {
-  stack_vars = read_terragrunt_config("stack_vars.hcl")
-  location   = local.stack_vars.locals.location
+  environment = "production"
+  location    = "us"
+  region      = "us-central1"
+  project_id  = get_env("TG_PRODUCTION_GCP_PROJECT")
 }
 
 stack "common" {

--- a/live/root.hcl
+++ b/live/root.hcl
@@ -1,8 +1,7 @@
 locals {
   stack_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.stack.hcl"))
-
-  project_id = local.stack_vars.locals.project_id
-  region     = local.stack_vars.locals.region
+  project_id = local.stack_vars.local.values.project_id
+  region     = local.stack_vars.local.values.region
 }
 
 generate "provider" {
@@ -38,4 +37,4 @@ terraform {
 EOF
 }
 
-inputs = local.stack_vars.locals
+inputs = local.stack_vars.local.values

--- a/live/root.hcl
+++ b/live/root.hcl
@@ -1,5 +1,5 @@
 locals {
-  stack_vars = read_terragrunt_config(find_in_parent_folders("stack_vars.hcl"))
+  stack_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.stack.hcl"))
 
   project_id = local.stack_vars.locals.project_id
   region     = local.stack_vars.locals.region

--- a/live/staging/stack_vars.hcl
+++ b/live/staging/stack_vars.hcl
@@ -1,6 +1,0 @@
-locals {
-  environment = "staging"
-  location    = "us"
-  region      = "us-central1"
-  project_id  = get_env("TG_STAGING_GCP_PROJECT")
-}

--- a/live/staging/terragrunt.stack.hcl
+++ b/live/staging/terragrunt.stack.hcl
@@ -1,6 +1,8 @@
 locals {
-  stack_vars = read_terragrunt_config("stack_vars.hcl")
-  location   = local.stack_vars.locals.location
+  environment = "staging"
+  location    = "us"
+  region      = "us-central1"
+  project_id  = get_env("TG_STAGING_GCP_PROJECT")
 }
 
 stack "common" {

--- a/modules/gcs_bucket/main.tf
+++ b/modules/gcs_bucket/main.tf
@@ -18,7 +18,7 @@ resource "google_storage_bucket" "bucket" {
 resource "google_storage_bucket_iam_binding" "readers" {
   bucket  = google_storage_bucket.bucket.name
   role    = "roles/storage.objectViewer"
-  members = var.readers
+  members = [var.reader]
 }
 
 resource "google_storage_bucket_iam_binding" "writers" {

--- a/modules/gcs_bucket/variables.tf
+++ b/modules/gcs_bucket/variables.tf
@@ -26,9 +26,8 @@ variable "versioning_enabled" {
   default = true
 }
 
-variable "readers" {
-  type    = list(string)
-  default = []
+variable "reader" {
+  type = string
 }
 
 variable "writers" {

--- a/stacks/common/terragrunt.stack.hcl
+++ b/stacks/common/terragrunt.stack.hcl
@@ -1,3 +1,7 @@
+locals {
+  values = values
+}
+
 unit "bucket" {
   source = "${get_repo_root()}/units/gcs-bucket"
   path   = "${values.location}/gcs-buckets/main"

--- a/units/gcs-bucket/terragrunt.hcl
+++ b/units/gcs-bucket/terragrunt.hcl
@@ -9,9 +9,9 @@ terraform {
 dependency "iam_svc_account" {
   config_path = "../../iam-svc-accounts/main"
 
-  mock_outputs_allowed_terraform_commands = ["validate"]
+  # mock_outputs_allowed_terraform_commands = ["plan", "validate"]
   mock_outputs = {
-    email = "hndrewaall@gmail.com"
+    email = "serviceAccount:hndrewaall@gmail.com"
   }
 }
 
@@ -20,7 +20,5 @@ inputs = {
   name_suffix = values.name_suffix
   environment = values.environment
   location    = values.location
-  readers = [
-    dependency.iam_svc_account.outputs.email
-  ]
+  reader      = dependency.iam_svc_account.outputs.email
 }


### PR DESCRIPTION
Error:

```
17:31:04.498 ERROR  Error: Unsupported block type


17:31:04.498 ERROR    on ./development/.terragrunt-stack/common/terragrunt.stack.hcl line 1, in unit "bucket":

17:31:04.498 ERROR     1: unit "bucket" {

17:31:04.498 ERROR  

17:31:04.499 ERROR  Blocks of type "unit" are not expected here.


17:31:04.499 ERROR  Error: Error in function call


17:31:04.499 ERROR    on ./root.hcl line 2, in locals:

17:31:04.499 ERROR     2:   stack_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.stack.hcl"))

17:31:04.499 ERROR  

17:31:04.499 ERROR  Call to function "read_terragrunt_config" failed: ./development/.terragrunt-stack/common/terragrunt.stack.hcl:1,1-5: Unsupported block type; Blocks
of type "unit" are not expected here..

```